### PR TITLE
Add COBS encoding utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 *.o
 *.a
+.vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ if(NOT CMAKE_BUILD_TYPE)
         FORCE)
 endif()
 
+# User options
+option(ENABLE_TESTS "Enable Tests" ON)
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 include_directories(ALF 
@@ -16,3 +19,7 @@ include_directories(ALF
 )
 
 add_subdirectory(libalf)
+if(${ENABLE_TESTS})
+    enable_testing()
+    add_subdirectory(tests)
+endif()

--- a/libalf/details/cobs.c
+++ b/libalf/details/cobs.c
@@ -5,10 +5,67 @@
 
 #include <libalf/details/cobs.h>
 
-size_t cobs_encode(const uint8_t *msg, size_t msg_len, uint8_t *out, size_t out_len) {
+size_t cobs_encode(const uint8_t *msg, size_t msg_len, uint8_t *out,
+                   size_t out_len) {
+  // TODO assert msg, out aren't null
+  // TODO assert out_len is large enough to store result
+  if (!msg || !out) {
     return 0;
+  }
+
+  size_t code = 1;
+  size_t code_idx = 0;
+  size_t write_idx = 1;
+
+  for (size_t idx = 0; idx < msg_len; ++idx) {
+    if (msg[idx] == LIBALF_COBS_DELIMITER_BYTE) {
+      out[code_idx] = code;
+      code_idx = write_idx++;
+      code = 1;
+    } else {
+      out[write_idx++] = msg[idx];
+      if (++code == 0xFF && (idx + 1) < msg_len) {
+        out[code_idx] = code;
+        code_idx = write_idx++;
+        code = 1;
+      }
+    }
+  }
+
+  out[code_idx] = code;
+  return write_idx;
 }
 
-size_t cobs_decode(const uint8_t *encoded_msg, size_t msg_len, uint8_t *out, size_t out_len) {
+size_t cobs_decode(const uint8_t *encoded_msg, size_t msg_len, uint8_t *out,
+                   size_t out_len) {
+  // TODO assert msg, out aren't null
+  // TODO assert out_len is large enough to store result
+  if (!encoded_msg || !out) {
     return 0;
+  }
+
+  size_t read_index = 0;
+  size_t write_index = 0;
+  uint8_t i;
+
+  while (read_index < msg_len) {
+    uint8_t code = encoded_msg[read_index];
+    // TODO assert code isn't LIBALF_DELIMITER BYTE
+    // TODO write script that CI can run to automatically create TODO issues
+
+    if (read_index + code > msg_len && code != 1) {
+      return 0;
+    }
+
+    read_index++;
+
+    for (uint8_t i = 1; i < code; ++i) {
+      out[write_index++] = encoded_msg[read_index++];
+    }
+    if (code != 0xFF && read_index != msg_len) {
+      out[write_index++] = 0x00;
+    }
+  }
+
+  return write_index;
 }

--- a/libalf/details/cobs.h
+++ b/libalf/details/cobs.h
@@ -10,13 +10,13 @@
 #define LIBALF_DETAILS_COBS_H
 
 #ifdef __cplusplus
-extern "C"
-{
+extern "C" {
 #endif
 
 /*******************************************************************************
  * Includes
  ******************************************************************************/
+#include <stddef.h>
 #include <stdint.h>
 
 /*******************************************************************************
@@ -26,33 +26,36 @@ extern "C"
 #define LIBALF_COBS_DELIMITER_BYTE (0x00)
 #endif
 
-    /**
-     * @brief: COBS encode a message
-     *
-     * @param msg:         message to encode
-     * @param msg_len:     length of message to encode
-     * @param out:         output buffer
-     * @param out_len:     length of output buffer
-     *
-     * @note: To ensure there is enough space for the encoded message in `out`
-     * the output buff should be at least `msg_len` + ceil(msg_len/254) bytes in
-     * size.
-     *
-     * @returns: Length of encoded message in bytes
-     */
-    size_t cobs_encode(const uint8_t *msg, size_t msg_len, uint8_t *out, size_t out_len);
+/**
+ * @brief: COBS encode a message
+ *
+ * @param msg:         message to encode
+ * @param msg_len:     length of message to encode
+ * @param out:         output buffer
+ * @param out_len:     length of output buffer
+ *
+ * @note: To ensure there is enough space for the encoded message in `out`
+ * the output buff should be at least `msg_len` + ceil(msg_len/254) bytes in
+ * size.
+ *
+ * @returns: Length of encoded message in bytes
+ */
+size_t cobs_encode(const uint8_t *msg, size_t msg_len, uint8_t *out,
+                   size_t out_len);
 
-    /**
-     * @brief: COBS decode a message
-     *
-     * @param encoded_msg:  message to decode
-     * @param msg_len:      length of encoded message
-     * @param out:          output buffer
-     * @param out_len:      length of output buffer
-     *
-     * @returns: Length of decoded message in bytes
-     */
-    size_t cobs_decode(const uint8_t *encoded_msg, size_t msg_len, uint8_t *out, size_t out_len);
+/**
+ * @brief: COBS decode a message
+ *
+ * @param encoded_msg:  message to decode
+ * @param msg_len:      length of encoded message
+ * @param out:          output buffer
+ * @param out_len:      length of output buffer
+ *
+ * @returns: Length of decoded message in bytes
+ *
+ */
+size_t cobs_decode(const uint8_t *encoded_msg, size_t msg_len, uint8_t *out,
+                   size_t out_len);
 
 #ifdef __cplusplus
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.10)
+file(GLOB_RECURSE alf_test_sources *)
+
+set(CMAKE_CXX_STANDARD 11)  # GoogleTest requires at least C++11
+
+include(FetchContent)
+FetchContent_Declare(
+    googletest
+    URL https://github.com/google/googletest/archive/refs/tags/release-1.11.0.zip
+)
+
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+
+add_executable(alf_tests ${alf_test_sources})
+
+target_link_libraries(alf_tests libalf)
+target_link_libraries(alf_tests gtest_main)
+
+include(GoogleTest)
+gtest_discover_tests(alf_tests)

--- a/tests/cobs.test.cpp
+++ b/tests/cobs.test.cpp
@@ -1,0 +1,173 @@
+#include <libalf/details/cobs.h>
+
+#include <gtest/gtest.h>
+
+TEST(CobsEncode, EncodeMsgIsNull) {
+  uint8_t *msg = NULL;
+  uint8_t out[256];
+  size_t len = cobs_encode(msg, 0, out, sizeof(out));
+
+  EXPECT_EQ(len, 0);
+}
+
+TEST(CobsEncode, EncodeOutIsNull) {
+  uint8_t msg[] = {1, 2, 3, 4, 5};
+  size_t len = cobs_encode(msg, sizeof(msg), NULL, 1000);
+
+  EXPECT_EQ(len, 0);
+}
+
+TEST(CobsEncode, EncodeZeroLengthMessage) {
+  uint8_t msg[] = {0};
+  uint8_t out[256];
+  size_t len = cobs_encode(msg, 0, out, sizeof(out));
+
+  EXPECT_EQ(len, 1);
+  EXPECT_EQ(out[0], 0x01);
+}
+
+TEST(CobsEncode, EncodeSmallMessageWithoutDelimiter) {
+  uint8_t msg[] = {0x11, 0x22, 0x33, 0x44};
+  uint8_t expected_msg[] = {0x05, 0x11, 0x22, 0x33, 0x44};
+  uint8_t encoded_msg[sizeof(msg) + 1] = {0};
+  size_t len = cobs_encode(msg, sizeof(msg), encoded_msg, sizeof(encoded_msg));
+
+  EXPECT_EQ(len, sizeof(msg) + 1);
+  EXPECT_TRUE(0 == memcmp(encoded_msg, expected_msg, sizeof(encoded_msg)));
+}
+
+TEST(CobsEncode, SmallMessageWithDelimiter) {
+  uint8_t msg[] = {0x11, 0x22, 0x00, 0x33};
+  uint8_t expected_msg[] = {0x03, 0x11, 0x22, 0x02, 0x33};
+  uint8_t encoded_msg[sizeof(msg) + 1] = {0};
+  size_t len = cobs_encode(msg, sizeof(msg), encoded_msg, sizeof(encoded_msg));
+
+  EXPECT_EQ(len, sizeof(msg) + 1);
+  EXPECT_TRUE(0 == memcmp(encoded_msg, expected_msg, sizeof(encoded_msg)));
+}
+
+TEST(CobsEncode, ByteLimitMessageWithoutDelimiter) {
+  uint8_t msg[0xFE];
+  uint8_t expected_msg[0xFF];
+  uint8_t encoded_msg[sizeof(msg) + 2] = {0};
+
+  // Build message: 0x01, 0x02, 0x03 ... 0xFD, 0xFE
+  for (size_t i = 1; i < 0xFF; ++i) {
+    msg[i - 1] = i;
+    expected_msg[i] = i;
+  }
+  expected_msg[0] = 0xFF;
+
+  size_t len = cobs_encode(msg, sizeof(msg), encoded_msg, sizeof(encoded_msg));
+
+  EXPECT_EQ(len, sizeof(msg) + 1);
+  EXPECT_TRUE(0 == memcmp(encoded_msg, expected_msg, sizeof(encoded_msg)));
+}
+
+TEST(CobsEncode, ByteLimitMessageWithDelimiter) {
+  uint8_t msg[0xFE];
+  uint8_t expected_msg[0xFF];
+  uint8_t encoded_msg[sizeof(msg) + 2] = {0};
+
+  // Build message: 0x00, 0x02, 0x03 ... 0xFD
+  for (size_t i = 0; i < 0xFE; ++i) {
+    msg[i] = i;
+    expected_msg[i + 1] = i;
+  }
+  expected_msg[0] = 0x01;
+  expected_msg[1] = 0xFE;
+
+  size_t len = cobs_encode(msg, sizeof(msg), encoded_msg, sizeof(encoded_msg));
+
+  EXPECT_EQ(len, sizeof(msg) + 1);
+  EXPECT_TRUE(0 == memcmp(encoded_msg, expected_msg, sizeof(encoded_msg)));
+}
+
+TEST(CobsEncode, ByteMaxMessageWithoutDelimiter) {
+  uint8_t msg[0xFF];
+  uint8_t expected_msg[0x101];
+  uint8_t encoded_msg[sizeof(msg) + 2] = {0};
+
+  // Build message: 0x01, 0x02, 0x03 ... 0xFF
+  for (size_t i = 0; i < 0xFF; ++i) {
+    msg[i] = i + 1;
+    expected_msg[i + 1] = i + 1;
+  }
+  expected_msg[0] = 0xFF;
+  expected_msg[0xFF] = 0x02;
+  expected_msg[0x100] = 0xFF;
+
+  size_t len = cobs_encode(msg, sizeof(msg), encoded_msg, sizeof(encoded_msg));
+
+  EXPECT_EQ(len, sizeof(msg) + 2);
+  EXPECT_TRUE(0 == memcmp(encoded_msg, expected_msg, sizeof(encoded_msg)));
+}
+
+TEST(CobsEncode, ByteMaxMessageWithDelimiter) {
+  uint8_t msg[0xFF];
+  uint8_t expected_msg[0x101] = {0};
+  uint8_t encoded_msg[sizeof(msg) + 1] = {0};
+
+  // Build message: 0x01, 0x02, 0x03 ... 0xFF
+  for (size_t i = 0; i < 0xFF; ++i) {
+    msg[i] = i;
+    expected_msg[i + 1] = i;
+  }
+  expected_msg[0] = 0x01;
+  expected_msg[1] = 0xFF;
+
+  size_t len = cobs_encode(msg, sizeof(msg), encoded_msg, sizeof(encoded_msg));
+
+  EXPECT_EQ(len, sizeof(msg) + 1);
+  EXPECT_TRUE(0 == memcmp(encoded_msg, expected_msg, sizeof(encoded_msg)));
+}
+
+TEST(CobsEncode, LongMessageOfAllZeroes) {
+  uint8_t msg[0x200] = {0};
+  uint8_t expected_msg[sizeof(msg) + 1];
+  uint8_t encoded_msg[sizeof(msg) + 1] = {0};
+
+  for (size_t i = 0; i < sizeof(expected_msg); ++i) {
+    expected_msg[i] = 0x01;
+  }
+
+  size_t len = cobs_encode(msg, sizeof(msg), encoded_msg, sizeof(encoded_msg));
+  EXPECT_EQ(len, sizeof(msg) + 1);
+  EXPECT_TRUE(0 == memcmp(encoded_msg, expected_msg, sizeof(encoded_msg)));
+}
+
+TEST(CobsDecode, MsgIsNULL) {
+  size_t len = cobs_decode(NULL, 20, (uint8_t *)0xDEADBEEF, 42);
+  EXPECT_EQ(len, 0);
+}
+
+TEST(CobsDecode, ZeroLengthMessage) {
+  size_t len = cobs_decode((uint8_t *)0xBAD, 0, (uint8_t *)0xBAD, 42);
+  EXPECT_EQ(len, 0);
+}
+
+TEST(CobsDecode, BasicMessage) {
+  uint8_t msg[] = {0x11, 0x22, 0x33, 0x44};
+  uint8_t encoded_msg[] = {0x05, 0x11, 0x22, 0x33, 0x44};
+  uint8_t decoded_msg[sizeof(msg)] = {0};
+
+  size_t len = cobs_decode(encoded_msg, sizeof(encoded_msg), decoded_msg,
+                           sizeof(decoded_msg));
+
+  EXPECT_EQ(len, sizeof(msg));
+  EXPECT_TRUE(0 == memcmp(msg, decoded_msg, sizeof(msg)));
+}
+
+TEST(CobsDecode, DecodeEncodedMessage) {
+  uint8_t msg[] = {0x11, 0x22, 0x00, 0x33};
+  uint8_t encoded_msg[sizeof(msg) + 1] = {0};
+  uint8_t decoded_msg[sizeof(msg)] = {0};
+
+  size_t enc_len =
+      cobs_encode(msg, sizeof(msg), encoded_msg, sizeof(encoded_msg));
+  size_t len =
+      cobs_decode(encoded_msg, enc_len, decoded_msg, sizeof(decoded_msg));
+
+  EXPECT_EQ(len, sizeof(msg));
+  EXPECT_TRUE(0 == memcmp(msg, decoded_msg, sizeof(msg)));
+}


### PR DESCRIPTION
Adds COBS encoding/decoding utilities. COBS will be the algorithm
used to unambigously frame packet data. COBS is an encoding scheme
that replaces any delimiter byte in a message with a non-delimiter
value. This allows us to use the delimiter byte (typically zero) as
a packet boundry. It also allows clients to easily re-sync to a
logging stream. They just need to listen for the next zero.